### PR TITLE
fix: get release-please to run properly by updating GitHub Actions versions

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,7 +11,7 @@ jobs:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
     steps:
-      - uses: GoogleCloudPlatform/release-please-action@v3
+      - uses: googleapis/release-please-action@v4
         id: release
         with:
           release-type: simple

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -41,7 +41,7 @@ jobs:
           poetry build
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist/
@@ -55,7 +55,7 @@ jobs:
       id-token: write
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist/


### PR DESCRIPTION
* chore: update release-please GitHub Actions versions and switch awayfrom deprecated version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated our release automation tool and artifact management actions to newer versions, aiming to enhance the overall release workflow and process management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->