### PR TITLE
fix: call logging.Handler init in base class

### DIFF
--- a/src/snakemake_interface_logger_plugins/base.py
+++ b/src/snakemake_interface_logger_plugins/base.py
@@ -18,6 +18,7 @@ class LogHandlerBase(ABC, Handler):
         common_settings: OutputSettingsLoggerInterface,
         settings: Optional[LogHandlerSettingsBase],
     ) -> None:
+        Handler.__init__(self)
         self.common_settings = common_settings
         self.settings = settings
         self.__post_init__()


### PR DESCRIPTION
fixes #33. logging.Handler init needs to be called to access its attributes.