### PR TITLE
Require emit() method implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,20 +53,26 @@ class LogHandler(LogHandlerBase):
         # self.settings.
         # You also have access to self.common_settings here, which are logging settings supplied by the caller in the form of OutputSettingsLoggerInterface. # noqa: E501
         # See https://github.com/snakemake/snakemake-interface-logger-plugins/blob/main/src/snakemake_interface_logger_plugins/settings.py for more details # noqa: E501
-        
+
         # access settings attributes
-        self.settings 
+        self.settings
         self.common_settings
 
     # Here you can override logging.Handler methods to customize logging behavior.
-    # For example, you can override the emit() method to control how log records
-    # are processed and output. See the Python logging documentation for details:
+    # Only an implementation of the emit() method is required. See the Python logging
+    # documentation for details:
     # https://docs.python.org/3/library/logging.html#handler-objects
 
     # LogRecords from Snakemake carry contextual information in the record's attributes
     # Of particular interest is the 'event' attribute, which indicates the type of log information contained
     # See https://github.com/snakemake/snakemake-interface-logger-plugins/blob/2ab84cb31f0b92cf0b7ee3026e15d1209729d197/src/snakemake_interface_logger_plugins/common.py#L33 # noqa: E501
     # For examples on parsing LogRecords, see https://github.com/cademirch/snakemake-logger-plugin-snkmt/blob/main/src/snakemake_logger_plugin_snkmt/parsers.py # noqa: E501
+
+    def emit(self, record):
+        # Actually emit the record. Typically this will call self.format(record) to
+        # convert the record to a formatted string. The result could then be written to
+        # a stream or file.
+        ...
 
     @property
     def writes_to_stream(self) -> bool:
@@ -147,7 +153,7 @@ class LogHandler(LogHandlerBase):
     def __post_init__(self) -> None:
         super().__post_init__()
         self.console = Console()
-    
+
     def emit(self, record):
         # Access event type from record
         if hasattr(record, 'event') and record.event == LogEvent.JOB_ERROR:
@@ -155,7 +161,7 @@ class LogHandler(LogHandlerBase):
             if hasattr(record, 'name') and record.name in ['rule1', 'rule2']:
                 logfile = record.log[0] if hasattr(record, 'log') else None
                 output = record.output[0] if hasattr(record, 'output') else "unknown"
-                
+
                 # Use rich console for pretty printing
                 self.console.print(f"[red]Error in {output}. See {logfile}[/red]")
                 if logfile:

--- a/src/snakemake_interface_logger_plugins/base.py
+++ b/src/snakemake_interface_logger_plugins/base.py
@@ -27,6 +27,13 @@ class LogHandlerBase(ABC, Handler):
     def __post_init__(self) -> None:
         pass
 
+    @abstractmethod
+    def emit(self, record: LogRecord) -> None:
+        """Actually log the given record.
+
+        This is called after the record has passed the handler's installed filter.
+        """
+
     @property
     @abstractmethod
     def writes_to_stream(self) -> bool:


### PR DESCRIPTION
 Plugin handler classes will not work without an implementation of `emit()` (the `logging.Handler` version just raises `NotImplementedError`). The README mentions overriding the method but it is not obvious that it is a requirement.

This updates the example code in the README to include an `emit()` method. It also marks the method as abstract in `LogHandlerBase`. The latter is not strictly required but would probably result in a clearer error message, and the class already inherits from ABC.